### PR TITLE
feat!: Support different default branches

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14]
+        node: [12, 14, 16]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/index.js
+++ b/index.js
@@ -34,8 +34,6 @@ class Downloader {
     this.cache = new Keyv(cacheOpts);
 
     this._octokit = new Octokit(options.github);
-
-    // this._files = new Map();
   }
 
   async recurseTree(owner, repo, directory, options = {}) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Blaine Bublitz <blaine.bublitz@gmail.com> (https://github.com/phated)",
   "license": "MIT",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
-    "@octokit/rest": "^17.10.0",
+    "@octokit/rest": "^18.12.0",
     "keyv": "^4.0.1",
     "minimist": "^1.2.0"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "expect": "^26.0.1",
+    "eslint": "^7.0.0",
+    "expect": "^27.0.0",
     "keyv-file": "^0.2.0",
-    "mocha": "^7.2.0",
+    "mocha": "^8.0.0",
     "nyc": "^15.1.0"
   },
   "prettier": {

--- a/test/index.js
+++ b/test/index.js
@@ -50,7 +50,7 @@ describe('github-download-directory', function () {
     });
 
     it('uses the cache values if available', async function () {
-      var key = 'phated/github-download-directory#master';
+      var key = 'phated/github-download-directory';
       var cachedTree = await downloader.cache.get(key);
       await downloader.cache.set(key, cachedTree.filter(onlyIndex));
 


### PR DESCRIPTION
Closes #6

It turns out that github stopped supporting references in the `git.getTree` API, so I have to implement the recursion myself using the `repos.gitContent` API.

I suppose I'll mark this as breaking too.